### PR TITLE
Add option to disable the default CSS injected into the HEAD

### DIFF
--- a/export.js
+++ b/export.js
@@ -61,7 +61,12 @@ _.extend(Avatar, {
 
     // Default text color when displaying the initials.
     // Can also be set to a function to map an user object to a text color.
-    textColor: "#fff"
+    textColor: "#fff",
+
+    // Default CSS included in the head of your application.
+    // Setting this to false, or 0, will exclude the default CSS and leave the 
+    // avatar unstyled by the package.
+    includeDefaultCSS: 1
 
   },
 
@@ -70,7 +75,9 @@ _.extend(Avatar, {
 
   setOptions: function(options) {
     Avatar.options = _.extend(Avatar.options, options);
-    createCSS();
+    if (Avatar.options.includeDefaultCSS) {
+      createCSS();
+    }
   },
 
   // Returns the cssClassPrefix property from options


### PR DESCRIPTION
as per the issue I opened here  : #20 it would be beneficial to optionally exclude the default CSS in a production environment.
