### PR TITLE
Improve getService function to check user services picture subvalues before returning

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -4,8 +4,11 @@ getService = function (user) {
   var services = user && user.services || {};
   var customProp = user && Avatar.options.customImageProperty;
   if (customProp && getDescendantProp(user, customProp)) { return 'custom'; }
-  var service = _.find(['twitter', 'facebook', 'google', 'github', 'instagram', 'linkedin'], function(s) { return !!services[s]; });
-  return service || 'none';
+  var service = _.find([['twitter', 'profile_image_url_https'], ['facebook', 'id'], ['google', 'picture'], ['github', 'username'], ['instagram', 'profile_picture'], ['linkedin', 'pictureUrl']], function(s) { return !!services[s[0]] && s[1].length && !!services[s[0]][s[1]]; });
+  if(!service)
+    return 'none';
+  else
+    return service[0];
 };
 
 getGravatarUrl = function (user, defaultUrl) {


### PR DESCRIPTION
I had a problem where some of the subvalues of services were not published to the client side and Avatar displayed the initials although I also had a gravatar hash defined - a better fallback system overall when checking if the pics values really exist for Avatar.getURL function before returning the (“broken”) service and refusing to try to display a Gravatar image.
