### PR TITLE
Fix initials

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -72,7 +72,7 @@ customClasses = function (context) {
 
 // Returns the initials text for an avatar
 initialsText = function(user, context) {
-  return this.initials || Avatar.getInitials(user);
+  return context.initials || Avatar.getInitials(user);
 }
 
 // Creates the dynamically generated CSS file


### PR DESCRIPTION
The initials were never displayed, `this` corresponds to `Window`, not to the template data.
