### PR TITLE
Remove initials once images loaded using html onload

### DIFF
--- a/blaze/avatar.html
+++ b/blaze/avatar.html
@@ -1,6 +1,6 @@
 <template name="avatar">
   <div class="{{cssClassPrefix}} {{size}} {{shape}} {{class}}">
-    <img class="{{cssClassPrefix}}-image" src="{{imageUrl}}" alt="avatar" onerror="this.style.display='none';" />
+    <img class="{{cssClassPrefix}}-image" src="{{imageUrl}}" alt="avatar" onerror="this.style.display='none';" onload="this.nextElementSibling.style.display='none';" />
     <span class="{{cssClassPrefix}}-initials" style="{{initialsCss}}">{{initialsText}}</span>
   </div>
 </template>


### PR DESCRIPTION
Sometime, image is loaded (maybe loading is slow), but initials already blocked it (because of css z-index). I just put in html `onload` to make sure the initials display none when the image loaded. `<img class="{{cssClassPrefix}}-image" src="{{imageUrl}}" alt="avatar" onerror="this.style.display='none';" onload="this.nextElementSibling.style.display='none';" />`
